### PR TITLE
Bugfix/fix issue with start background monitoring handler empty listener on application start

### DIFF
--- a/beacon_monitoring/CHANGELOG.md
+++ b/beacon_monitoring/CHANGELOG.md
@@ -1,3 +1,10 @@
 ## 1.0.0
 
 * Initial release.
+
+## 1.0.1
+
+* iOS - Remove `registrar` property from `MonitoringBackgroundHandler` instance init
+* iOS - Make `locationManager` property in `LocationService` not `lazy` to setup `locationManager.delegate` at service init
+* iOS - Add `preferencesStorage` property to `MonitoringBackgroundHandler` instance init
+* iOS - Add automatic setup of `beaconService` delegate to `MonitoringBackgroundHandler` instance init to automatically setup listener

--- a/beacon_monitoring/README.md
+++ b/beacon_monitoring/README.md
@@ -14,6 +14,89 @@ dependencies:
   beacon_monitoring: latest
 ```
 
+##  iOS Setup
+
+#### 1. Update Info.plist
+> For deployment targets earlier than iOS 13, add both NSBluetoothAlwaysUsageDescription and NSBluetoothPeripheralUsageDescription to your app’s Information Property List file. Devices running earlier versions of iOS rely on NSBluetoothPeripheralUsageDescription, while devices running later versions rely on NSBluetoothAlwaysUsageDescription. [Read on Apple Documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/nsbluetoothperipheralusagedescription)
+
+* [NSLocationAlwaysAndWhenInUseUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationalwaysandwheninuseusagedescription)
+* [NSLocationWhenInUseUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocationwheninuseusagedescription)
+* [NSBluetoothAlwaysUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nsbluetoothalwaysusagedescription)
+* [NSBluetoothPeripheralUsageDescription](https://developer.apple.com/documentation/bundleresources/information_property_list/nsbluetoothperipheralusagedescription)
+
+Go to information property list `Info.plist` and add keys with human-readable messages (`Info.plist -> Open as -> Source Code`): 
+
+```
+<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+<string>A message that tells the user why the app is requesting access to the user’s location information at all times.</string>
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground.</string>
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>A message that tells the user why the app needs access to Bluetooth.</string>
+<key>NSBluetoothPeripheralUsageDescription</key>
+<string>A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals.</string>
+```
+#### 2. Update Capability
+1. Go to `Signing & Capabilities`
+2. Click `+ Capability`
+3. Add `Background Modes` capability
+4. Select `Location updates`
+
+#### 3. Update AppDelegate
+1. Open `AppDelegate.swift`
+2. Import `beacon_monitoring`
+2. Add static method to register plugins
+```swift
+static func registerPlugins(with registry: FlutterPluginRegistry) {
+  GeneratedPluginRegistrant.register(with: registry)
+}
+```
+3. Register your AppDelegate as a registry
+```swift 
+AppDelegate.registerPlugins(with: self)
+```
+4. Set `BeaconMonitoringPlugin` registrant callback
+```swift 
+BeaconMonitoringPlugin.setPluginRegistrantCallback { registry in
+  AppDelegate.registerPlugins(with: registry)
+}
+```
+
+So your `AppDelegate.swift` should look like: 
+```swift
+import UIKit
+import Flutter
+import beacon_monitoring
+
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate {
+
+    // MARK: - UIApplicationDelegate Methods
+    override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // ...
+        setupAppDelegateRegistry()
+        setupBeaconMonitoringPluginCallback()
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    // MARK: - Register Plugins
+    static func registerPlugins(with registry: FlutterPluginRegistry) {
+        GeneratedPluginRegistrant.register(with: registry)
+    }
+
+    // MARK: - Private Methods
+    private func setupAppDelegateRegistry() {
+        AppDelegate.registerPlugins(with: self)
+    }
+    private func setupBeaconMonitoringPluginCallback() {
+        BeaconMonitoringPlugin.setPluginRegistrantCallback { registry in
+            AppDelegate.registerPlugins(with: registry)
+        }
+    }
+}
+```
+
+
 ## Description
 The *beacon_monitoring* plugin can monitor for beacons while the app works in the foreground and in the background mode.
 

--- a/beacon_monitoring/example/ios/Runner/AppDelegate.swift
+++ b/beacon_monitoring/example/ios/Runner/AppDelegate.swift
@@ -4,52 +4,35 @@ import beacon_monitoring
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
-    let MINUTES_15: Int = 60*15
 
-    /// Registers all pubspec-referenced Flutter plugins in the given registry.
-    static func registerPlugins(with registry: FlutterPluginRegistry) {
-            GeneratedPluginRegistrant.register(with: registry)
-       }
-
-    override func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-    ) -> Bool {
-        setupFirebase()
-        setupDynamicLinks()
-        setupPluginRegistrantCallback()
-        setupBackgroundMode()
+    // MARK: - UIApplicationDelegate Methods
+    override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // ...
         setupNotificationService()
+        setupAppDelegateRegistry()
+        setupBeaconMonitoringPluginCallback()
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 
+    // MARK: - Register Plugins
+    static func registerPlugins(with registry: FlutterPluginRegistry) {
+        GeneratedPluginRegistrant.register(with: registry)
+    }
+
     // MARK: - Private Methods
-    private func setupFirebase() {
-
-    }
-    private func setupDynamicLinks() {
-
-    }
-    private func setupPluginRegistrantCallback() {
-        // Register the app's plugins in the context of a normal run
+    private func setupAppDelegateRegistry() {
         AppDelegate.registerPlugins(with: self)
-
-        // The following code will be called upon WorkmanagerPlugin's registration.
-        // Note : all of the app's plugins may not be required in this context ;
-        // instead of using GeneratedPluginRegistrant.register(with: registry),
-        // you may want to register only specific plugins.
+    }
+    private func setupBeaconMonitoringPluginCallback() {
         BeaconMonitoringPlugin.setPluginRegistrantCallback { registry in
             AppDelegate.registerPlugins(with: registry)
         }
-    }
-    private func setupBackgroundMode() {
-        UIApplication.shared.setMinimumBackgroundFetchInterval(TimeInterval(MINUTES_15))
     }
     private func setupNotificationService() {
         UNUserNotificationCenter.current().delegate = self
     }
 
-    // MARK: - UNUserNotificationCenter Delegate Methods
+    // MARK: - UNUserNotificationCenterDelegate Methods
     override func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,

--- a/beacon_monitoring/example/ios/Runner/Info.plist
+++ b/beacon_monitoring/example/ios/Runner/Info.plist
@@ -22,16 +22,23 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>NSLocationAlwaysAndWhenInUseUsageDescription</string>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string>NSLocationAlwaysUsageDescription</string>
+    <string>A message that tells the user why the app is requesting access to the user’s location information at all times.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>A message that tells the user why the app is requesting access to the user’s location information while the app is running in the foreground.</string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>A message that tells the user why the app needs access to Bluetooth.</string>
+    <key>NSBluetoothPeripheralUsageDescription</key>
+    <string>A message that tells the user why the app is requesting the ability to connect to Bluetooth peripherals.</string>
+
+
+
+
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>location</string>
 	</array>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>NSLocationWhenInUseUsageDescription</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/beacon_monitoring/ios/Classes/BeaconMonitoringPlugin.swift
+++ b/beacon_monitoring/ios/Classes/BeaconMonitoringPlugin.swift
@@ -20,7 +20,7 @@ public class BeaconMonitoringPlugin: FlutterPluginAppLifeCycleDelegate {
     private init(registrar: FlutterPluginRegistrar) {
         monitoringBackgroundHandler = MonitoringBackgroundHandler(
             beaconService: dependencyContainer.beaconService,
-            registrar: registrar)
+            preferencesStorage: dependencyContainer.preferencesStorage)
 
         super.init()
         self.setupDependencies()

--- a/beacon_monitoring/ios/Classes/Dependency/LocationService.swift
+++ b/beacon_monitoring/ios/Classes/Dependency/LocationService.swift
@@ -33,14 +33,21 @@ final class LocationService: NSObject {
     weak var delegate: LocationServiceDelegate?
 
     // MARK: - Private Properties
-    private lazy var locationManager: CLLocationManager = {
-        let locationManager = CLLocationManager()
-        locationManager.delegate = self
+    private let locationManager = CLLocationManager()
+
+    // MARK: - Instance Initialization
+    override init() {
+        super.init()
+        setupLocationManager()
+    }
+
+    // MARK: - Private Methods
+    private func setupLocationManager() {
         locationManager.pausesLocationUpdatesAutomatically = false
         locationManager.startMonitoringSignificantLocationChanges()
         locationManager.allowsBackgroundLocationUpdates = true
-        return locationManager
-    }()
+        locationManager.delegate = self
+    }
 
 }
 

--- a/beacon_monitoring/pubspec.yaml
+++ b/beacon_monitoring/pubspec.yaml
@@ -1,6 +1,6 @@
 name: beacon_monitoring
 description: A Flutter plugin for monitoring beacons on mobile platforms. Supports iOS and Android.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/ObjectivityLtd/beacon_monitoring
 
 environment:

--- a/beacon_monitoring_platform_interface/CHANGELOG.md
+++ b/beacon_monitoring_platform_interface/CHANGELOG.md
@@ -1,3 +1,10 @@
 ## 1.0.0
 
 * Initial release.
+
+## 1.0.1
+
+* iOS - Remove `registrar` property from `MonitoringBackgroundHandler` instance init
+* iOS - Make `locationManager` property in `LocationService` not `lazy` to setup `locationManager.delegate` at service init
+* iOS - Add `preferencesStorage` property to `MonitoringBackgroundHandler` instance init
+* iOS - Add automatic setup of `beaconService` delegate to `MonitoringBackgroundHandler` instance init to automatically setup listener

--- a/beacon_monitoring_platform_interface/CHANGELOG.md
+++ b/beacon_monitoring_platform_interface/CHANGELOG.md
@@ -1,10 +1,3 @@
 ## 1.0.0
 
 * Initial release.
-
-## 1.0.1
-
-* iOS - Remove `registrar` property from `MonitoringBackgroundHandler` instance init
-* iOS - Make `locationManager` property in `LocationService` not `lazy` to setup `locationManager.delegate` at service init
-* iOS - Add `preferencesStorage` property to `MonitoringBackgroundHandler` instance init
-* iOS - Add automatic setup of `beaconService` delegate to `MonitoringBackgroundHandler` instance init to automatically setup listener

--- a/beacon_monitoring_platform_interface/pubspec.yaml
+++ b/beacon_monitoring_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: beacon_monitoring_platform_interface
 description: A common platform interface for the beacon_monitoring plugin.
-version: 1.0.1
+version: 1.0.0
 homepage: https://github.com/ObjectivityLtd/beacon_monitoring
 
 environment:

--- a/beacon_monitoring_platform_interface/pubspec.yaml
+++ b/beacon_monitoring_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: beacon_monitoring_platform_interface
 description: A common platform interface for the beacon_monitoring plugin.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/ObjectivityLtd/beacon_monitoring
 
 environment:


### PR DESCRIPTION
- Add beaconService listener setup to `MonitoringBackgroundHandler` init for case when background monitoring was already started.
- Remove `registrar` property from `MonitoringBackgroundHandler` init.
- Add `preferencesStorage` property to `MonitoringBackgroundHandler` init.
- Make `locationManager` property in `LocationService` not `lazy` to setup `locationManager.delegate` on service start.
- Add iOS setup documentation to `README`
- Update plugin version 
- Update `CHANGELOG `