### PR TITLE
Fix ranging on iOS

### DIFF
--- a/beacon_monitoring/ios/Classes/Dependency/LocationService.swift
+++ b/beacon_monitoring/ios/Classes/Dependency/LocationService.swift
@@ -44,7 +44,6 @@ final class LocationService: NSObject {
     // MARK: - Private Methods
     private func setupLocationManager() {
         locationManager.pausesLocationUpdatesAutomatically = false
-        locationManager.startMonitoringSignificantLocationChanges()
         locationManager.allowsBackgroundLocationUpdates = true
         locationManager.delegate = self
     }

--- a/beacon_monitoring_platform_interface/lib/src/model/monitoring_result.dart
+++ b/beacon_monitoring_platform_interface/lib/src/model/monitoring_result.dart
@@ -73,7 +73,11 @@ extension MonitoringStateExtension on MonitoringState {
   static parse(String? value) {
     if (_StringExtension.isBlank(value)) return null;
 
-    return MonitoringState.values.firstWhere((e) => describeEnum(e) == value);
+    try {
+      return MonitoringState.values.firstWhere((e) => describeEnum(e) == value);
+    } catch (_) {
+      return null;
+    }
   }
 
   String toJson() {


### PR DESCRIPTION
Some minor fixes I did to make ranging work on iOS. See #16 

What I did here:
- Found a small problem with a callback handler and `null` values
- ranging now starts the ranging on the location manager correctly. Previously it was just also starting monitoring
- disable `startMonitoringSignificantLocationChanges` because that is not needed. And also was "never" stopped again. This would mean that the iOS app is now woken up all the time when the user moves a couple of hundred meters.. This it not what we want, it should only be woken up when the beacon was detected, which is happening when you register a beacon monitoring and have the Background Location Permission (always) and correct Background-Mode for location set.

So far I also noticed the following other issues
- Using Core Bluetooth is not necessary to monitor/range beacons in iOS. Also, one other downside is that the Bluetooth permission is directly asked when the app starts because you cannot delay this. As soon as you instantiate the CoreBluetooth manager in iOS, it will ask for permissions. Should Bluetooth be removed for iOS?
- When using background monitoring, I had to re-compile the code, and then my callback was working. Maybe we should mention this in the readme? Also when I hot-restart the code changes are not directly used. So for example If I print some logging, I have to re-compile for the changes to take effect.